### PR TITLE
Feat:git config nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -57,8 +57,9 @@
       "reis.holmes" = {
         fullName = "Reis Holmes";
         name = "reis.holmes";
-        # No email - work email stays out of nix
+        workEmail = "reis.holmes@optimizely.com";
         signingKeyPub = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINNBSXWl4vHikJV3SOXxLdHq005sD3a/QIsvRfXGY3R2 4367558+reisholmes@users.noreply.github.com";
+        workSigningKeyPub = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKouJmVbhP+ojiWpSH4RDiVg/DQb0uHrVxFWztKEQ3u3 work-signing-key";
       };
       reis = {
         fullName = "Reis Holmes";

--- a/flake.nix
+++ b/flake.nix
@@ -57,10 +57,14 @@
       "reis.holmes" = {
         fullName = "Reis Holmes";
         name = "reis.holmes";
+        # No email - work email stays out of nix
+        signingKeyPub = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINNBSXWl4vHikJV3SOXxLdHq005sD3a/QIsvRfXGY3R2 4367558+reisholmes@users.noreply.github.com";
       };
       reis = {
         fullName = "Reis Holmes";
         name = "reis";
+        email = "4367558+reisholmes@users.noreply.github.com";
+        signingKeyPub = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINNBSXWl4vHikJV3SOXxLdHq005sD3a/QIsvRfXGY3R2 4367558+reisholmes@users.noreply.github.com";
       };
     };
 

--- a/home/reis.holmes/reisholmes/default.nix
+++ b/home/reis.holmes/reisholmes/default.nix
@@ -7,12 +7,13 @@
   ...
 }:
 let
-  # Personal email for personal repos only (work email stays out of nix)
+  # Personal email for personal repos
   personalEmail = "4367558+reisholmes@users.noreply.github.com";
 
-  # Generate allowed_signers file for SSH commit verification
+  # Generate allowed_signers file for SSH commit verification (both personal and work keys)
   allowedSignersFile = pkgs.writeText "git-allowed-signers" ''
     ${personalEmail} ${userConfig.signingKeyPub}
+    ${userConfig.workEmail} ${userConfig.workSigningKeyPub}
   '';
 in {
   imports = [
@@ -51,15 +52,17 @@ in {
 
     # Conditional includes for work/personal repositories
     includes = [
-      # Work repositories - email not set in nix (set manually if needed)
+      # Work repositories
       {
         condition = "gitdir:~/Documents/code/repos/";
         contents = {
           user = {
             name = "Reis Holmes";
-            # email = "work@company.com"; # Set this manually with: git config --global user.email "your-work-email"
+            email = userConfig.workEmail;
           };
-          commit.gpgsign = false; # Disable signing for work repos
+          gpg.format = "ssh";
+          user.signingkey = "~/.ssh/github_work_signing.pub";
+          commit.gpgsign = true;
           url = {
             "git@github-work:".insteadOf = [
               "git@github.com:"

--- a/home/reis.holmes/reisholmes/default.nix
+++ b/home/reis.holmes/reisholmes/default.nix
@@ -1,8 +1,20 @@
 {
+  config,
+  pkgs,
   nhModules,
   inputs,
+  userConfig,
   ...
-}: {
+}:
+let
+  # Personal email for personal repos only (work email stays out of nix)
+  personalEmail = "4367558+reisholmes@users.noreply.github.com";
+
+  # Generate allowed_signers file for SSH commit verification
+  allowedSignersFile = pkgs.writeText "git-allowed-signers" ''
+    ${personalEmail} ${userConfig.signingKeyPub}
+  '';
+in {
   imports = [
     "${nhModules}/common"
     "${nhModules}/dev"
@@ -18,6 +30,73 @@
   # Host-specific shell aliases
   programs.zsh.shellAliases = {
     nix_rebuild = "sudo darwin-rebuild switch --flake ~/Documents/code/personal_repos/nixCombined#reisholmes && nvd diff $(/bin/ls -d1v /nix/var/nix/profiles/system-*-link | tail -2 | head -1) $(/bin/ls -d1v /nix/var/nix/profiles/system-*-link | tail -1)";
+  };
+
+  # Create allowed_signers file for git SSH signing
+  home.file.".ssh/allowed_signers".source = allowedSignersFile;
+
+  # Git configuration
+  programs.git = {
+    # Git settings (new format)
+    settings = {
+      # No default email - work email stays out of nix, personal email set in conditional includes
+
+      # SSH signing configuration
+      gpg.format = "ssh";
+      gpg.ssh = {
+        allowedSignersFile = "~/.ssh/allowed_signers";
+        program = "/usr/bin/ssh-keygen"; # Use system ssh-keygen on macOS
+      };
+    };
+
+    # Conditional includes for work/personal repositories
+    includes = [
+      # Work repositories - email not set in nix (set manually if needed)
+      {
+        condition = "gitdir:~/Documents/code/repos/";
+        contents = {
+          user = {
+            name = "Reis Holmes";
+            # email = "work@company.com"; # Set this manually with: git config --global user.email "your-work-email"
+          };
+          commit.gpgsign = false; # Disable signing for work repos
+          url = {
+            "git@github-work:".insteadOf = [
+              "git@github.com:"
+              "https://github.com/"
+            ];
+            "github-work:optimizely/".insteadOf = [
+              "git@github.com:optimizely/"
+              "https://github.com/optimizely/"
+            ];
+            "github-work:episerver/".insteadOf = [
+              "https://github.com/episerver/"
+            ];
+          };
+        };
+      }
+      # Personal repositories
+      {
+        condition = "gitdir:~/Documents/code/personal_repos/";
+        contents = {
+          user = {
+            email = personalEmail;
+            name = "reisholmes";
+          };
+          gpg.format = "ssh";
+          user.signingkey = "~/.ssh/github_commit_signing_personal.pub";
+          commit.gpgsign = true;
+          gpg.ssh = {
+            program = "/usr/bin/ssh-keygen";
+            allowedSignersFile = "~/.ssh/allowed_signers";
+          };
+          url."git@github-personal:".insteadOf = [
+            "git@github.com:"
+            "https://github.com/"
+          ];
+        };
+      }
+    ];
   };
 
   # Stylix configuration for darwin home-manager

--- a/home/reis/reis-new/default.nix
+++ b/home/reis/reis-new/default.nix
@@ -1,9 +1,16 @@
 {
+  config,
   nhModules,
   nixgl,
   pkgs,
+  userConfig,
   ...
-}: {
+}: let
+  # Generate allowed_signers file for SSH commit verification
+  allowedSignersFile = pkgs.writeText "git-allowed-signers" ''
+    ${userConfig.email} ${userConfig.signingKeyPub}
+  '';
+in {
   imports = [
     "${nhModules}/common"
     "${nhModules}/dev"
@@ -18,6 +25,30 @@
   # Host-specific shell aliases
   programs.zsh.shellAliases = {
     nix_rebuild = "home-manager switch --flake .#reis@reis-new --impure -b backup && nvd diff $(home-manager generations | head -2 | tail -1 | awk '{print $7}') $(home-manager generations | head -1 | awk '{print $7}')";
+  };
+
+  # Create allowed_signers file for git SSH signing
+  home.file.".ssh/allowed_signers".source = allowedSignersFile;
+
+  # Git configuration
+  programs.git = {
+    # Enable SSH signing globally (personal computer - all repos signed)
+    signing = {
+      key = "/home/reis/.ssh/private-signing-key-github";
+      signByDefault = true;
+    };
+
+    # Git settings (new format)
+    settings = {
+      # Set personal email from userConfig
+      user.email = userConfig.email;
+
+      # SSH signing configuration
+      gpg.format = "ssh";
+      gpg.ssh = {
+        allowedSignersFile = "/home/reis/.ssh/allowed_signers";
+      };
+    };
   };
 
   # Packages specific to this machine

--- a/hosts/reis-new/README.md
+++ b/hosts/reis-new/README.md
@@ -38,6 +38,128 @@ This script will:
 - Build and install the DKMS module
 - Run sensors auto-detection
 
+## Git Configuration
+
+Git is managed through Nix with SSH commit signing enabled globally.
+
+### What's Automated
+
+- Git installation and base configuration
+- Delta for enhanced diffs
+- GitHub CLI credential helper
+- SSH signing configuration
+- Allowed signers file generation
+
+### Manual Setup Required
+
+#### SSH Keys
+
+The following SSH keys must be manually maintained:
+
+1. **GitHub Authentication**: `~/.ssh/github_reish`
+   - Used for git operations
+   - Configured in SSH config
+
+2. **Commit Signing Key**: `/home/reis/.ssh/private-signing-key-github`
+   - **Private key**: `/home/reis/.ssh/private-signing-key-github`
+   - **Public key**: `/home/reis/.ssh/private-signing-key-github.pub`
+   - Used for signing all commits
+   - Public key must be added to GitHub as a **Signing Key**
+
+#### Initial Setup Steps
+
+1. **Import Signing Key from Proton Pass**:
+   ```bash
+   # Copy private key from Proton Pass
+   cat > ~/.ssh/private-signing-key-github
+   # Paste private key, then Ctrl+D
+
+   # Copy public key from Proton Pass
+   cat > ~/.ssh/private-signing-key-github.pub
+   # Paste public key, then Ctrl+D
+
+   # Set correct permissions
+   chmod 600 ~/.ssh/private-signing-key-github
+   chmod 644 ~/.ssh/private-signing-key-github.pub
+   ```
+
+2. **Add Signing Key to GitHub**:
+   ```bash
+   # Display public key
+   cat ~/.ssh/private-signing-key-github.pub
+   ```
+   - Go to GitHub Settings → SSH and GPG keys
+   - Click "New SSH key"
+   - Title: "reis-new Commit Signing Key"
+   - Key type: **Signing Key** (important!)
+   - Paste the public key
+
+3. **Verify SSH Config** (`~/.ssh/config`):
+   ```
+   Host github.com
+     HostName github.com
+     PreferredAuthentications publickey
+     IdentityFile ~/.ssh/github_reish
+     UpdateHostKeys yes
+   ```
+
+4. **Test Configuration**:
+   ```bash
+   # Test SSH connection
+   ssh -T git@github.com
+
+   # Test commit signing
+   cd ~/Documents/code/personal_repos/*
+   git commit --allow-empty -m "test: verify signing"
+   git log --show-signature -1
+   git reset --hard HEAD~1  # Remove test commit
+   ```
+
+### Configuration Details
+
+- **Email**: `4367558+reisholmes@users.noreply.github.com` (GitHub private email)
+- **Name**: `Reis Holmes` (from userConfig)
+- **Commit Signing**: Enabled globally for all repositories
+- **Signing Format**: SSH
+- **Signing Key**: `/home/reis/.ssh/private-signing-key-github`
+
+### Verification
+
+Check your configuration:
+
+```bash
+# Show git config
+git config --list --show-origin | grep -E "(user\.|gpg\.|commit\.)"
+
+# Should show:
+# user.name=Reis Holmes
+# user.email=4367558+reisholmes@users.noreply.github.com
+# commit.gpgsign=true
+# gpg.format=ssh
+```
+
+### Troubleshooting
+
+#### Signing Not Working
+
+1. **Check signing key exists**:
+   ```bash
+   ls -la ~/.ssh/private-signing-key-github*
+   ```
+
+2. **Verify allowed_signers file**:
+   ```bash
+   cat ~/.ssh/allowed_signers
+   # Should contain: 4367558+reisholmes@users.noreply.github.com ssh-ed25519 ...
+   ```
+
+3. **Test signing**:
+   ```bash
+   cd ~/Documents/code/personal_repos/*
+   git commit --allow-empty -m "test"
+   git log --show-signature -1
+   ```
+
 ## Manual Setup Details
 
 The sections below document the manual steps for reference. Most of these are automated by the scripts above.

--- a/hosts/reisholmes/README.md
+++ b/hosts/reisholmes/README.md
@@ -1,0 +1,198 @@
+# reisholmes (macOS) Configuration
+
+macOS machine for both work and personal development.
+
+## System Information
+
+- **OS**: macOS
+- **User**: reis.holmes
+- **Configuration**: nix-darwin + home-manager
+
+## Git Configuration
+
+Git is managed through Nix with conditional includes for work and personal repositories.
+
+### What's Automated
+
+- Git installation and base configuration
+- Delta for enhanced diffs
+- GitHub CLI credential helper
+- Conditional configuration based on repository location
+- SSH signing setup for personal repos
+- Allowed signers file generation
+
+### Manual Setup Required
+
+#### SSH Keys
+
+The following SSH keys must be manually maintained:
+
+1. **Personal GitHub Authentication**: `~/.ssh/GitHub-Personal-SSHKey`
+   - Used for git operations on personal repositories
+   - Configured via SSH config with `github-personal` host
+
+2. **Personal Commit Signing Key**: `~/.ssh/github_commit_signing_personal`
+   - **Private key**: `~/.ssh/github_commit_signing_personal`
+   - **Public key**: `~/.ssh/github_commit_signing_personal.pub`
+   - Used for signing commits in personal repositories
+   - Public key must be added to GitHub as a **Signing Key**
+
+3. **Work GitHub Authentication** (if applicable): `~/.ssh/github-work`
+   - Used for git operations on work repositories
+   - Configured via SSH config with `github-work` host
+
+#### Initial Setup Steps
+
+1. **Generate or Import Signing Key**:
+   ```bash
+   # Option A: Generate new key
+   ssh-keygen -t ed25519 -C "4367558+reisholmes@users.noreply.github.com" \
+     -f ~/.ssh/github_commit_signing_personal -N ""
+
+   # Option B: Import from Proton Pass
+   # Copy private key → ~/.ssh/github_commit_signing_personal
+   # Copy public key → ~/.ssh/github_commit_signing_personal.pub
+   chmod 600 ~/.ssh/github_commit_signing_personal
+   chmod 644 ~/.ssh/github_commit_signing_personal.pub
+   ```
+
+2. **Add Signing Key to GitHub**:
+   ```bash
+   # Display public key
+   cat ~/.ssh/github_commit_signing_personal.pub
+   ```
+   - Go to GitHub Settings → SSH and GPG keys
+   - Click "New SSH key"
+   - Title: "macOS Commit Signing Key"
+   - Key type: **Signing Key** (important!)
+   - Paste the public key
+
+3. **Verify SSH Config** (`~/.ssh/config`):
+   ```
+   # Personal GitHub
+   Host github-personal
+     HostName github.com
+     User git
+     IdentityFile ~/.ssh/GitHub-Personal-SSHKey
+     IdentitiesOnly yes
+
+   # Work GitHub
+   Host github-work
+     HostName github.com
+     User git
+     IdentityFile ~/.ssh/github-work
+     IdentitiesOnly yes
+   ```
+
+4. **Test Configuration**:
+   ```bash
+   # Test SSH connections
+   ssh -T git@github-personal
+   ssh -T git@github-work
+
+   # Test commit signing in personal repo
+   cd ~/Documents/code/personal_repos/nixCombined
+   git commit --allow-empty -m "test: verify signing"
+   git log --show-signature -1
+   git reset --hard HEAD~1  # Remove test commit
+   ```
+
+## How Git Configuration Works
+
+### Directory-Based Configuration
+
+Git uses conditional includes to apply different settings based on repository location:
+
+#### Personal Repositories (`~/Documents/code/personal_repos/`)
+- **Email**: `4367558+reisholmes@users.noreply.github.com` (GitHub private email)
+- **Name**: `reisholmes`
+- **Commit Signing**: Enabled (SSH)
+- **Signing Key**: `~/.ssh/github_commit_signing_personal.pub`
+- **SSH Host**: `github-personal` (uses personal SSH key)
+- **URL Rewrite**: All GitHub URLs use `git@github-personal:`
+
+#### Work Repositories (`~/Documents/code/repos/`)
+- **Email**: Not set in Nix (configure manually if needed)
+- **Name**: `Reis Holmes`
+- **Commit Signing**: Disabled
+- **SSH Host**: `github-work` (uses work SSH key)
+- **URL Rewrite**: All GitHub URLs use `git@github-work:`
+- **Work Email Setup** (if needed):
+  ```bash
+  cd ~/Documents/code/repos
+  git config user.email "your-work-email@company.com"
+  ```
+
+### Verification
+
+Check your current configuration:
+
+```bash
+# Show all git config with sources
+git config --list --show-origin
+
+# Check user info in a specific repo
+cd ~/Documents/code/personal_repos/nixCombined
+git config user.email  # Should show GitHub private email
+git config user.name   # Should show: reisholmes
+
+cd ~/Documents/code/repos/<some-work-repo>
+git config user.email  # Your work email (if set)
+git config user.name   # Should show: Reis Holmes
+```
+
+## Rebuilding Configuration
+
+After making changes to your Nix configuration:
+
+```bash
+sudo darwin-rebuild switch --flake ~/Documents/code/personal_repos/nixCombined#reisholmes
+```
+
+Or use the alias:
+```bash
+nix_rebuild
+```
+
+## Troubleshooting
+
+### Signing Not Working
+
+1. **Check signing key exists**:
+   ```bash
+   ls -la ~/.ssh/github_commit_signing_personal*
+   ```
+
+2. **Verify allowed_signers file**:
+   ```bash
+   cat ~/.ssh/allowed_signers
+   # Should contain: 4367558+reisholmes@users.noreply.github.com ssh-ed25519 ...
+   ```
+
+3. **Test signing manually**:
+   ```bash
+   cd ~/Documents/code/personal_repos/nixCombined
+   git commit --allow-empty -m "test"
+   git log --show-signature -1
+   ```
+
+### Wrong Email in Commits
+
+Verify you're in the correct directory context:
+```bash
+pwd  # Check current directory
+git config --get user.email  # Check what git will use
+```
+
+### SSH Connection Issues
+
+Test SSH connections:
+```bash
+ssh -vT git@github-personal  # Should succeed
+ssh -vT git@github-work      # Should succeed
+```
+
+If failing, check:
+1. SSH keys exist and have correct permissions (600 for private, 644 for public)
+2. `~/.ssh/config` has correct host configurations
+3. Keys are added to respective GitHub accounts

--- a/hosts/reisholmes/README.md
+++ b/hosts/reisholmes/README.md
@@ -18,8 +18,8 @@ Git is managed through Nix with conditional includes for work and personal repos
 - Delta for enhanced diffs
 - GitHub CLI credential helper
 - Conditional configuration based on repository location
-- SSH signing setup for personal repos
-- Allowed signers file generation
+- SSH signing setup for both personal and work repos
+- Allowed signers file generation (both keys)
 
 ### Manual Setup Required
 
@@ -37,9 +37,15 @@ The following SSH keys must be manually maintained:
    - Used for signing commits in personal repositories
    - Public key must be added to GitHub as a **Signing Key**
 
-3. **Work GitHub Authentication** (if applicable): `~/.ssh/github-work`
+3. **Work GitHub Authentication**: `~/.ssh/github-work`
    - Used for git operations on work repositories
    - Configured via SSH config with `github-work` host
+
+4. **Work Commit Signing Key**: `~/.ssh/github_work_signing`
+   - **Private key**: `~/.ssh/github_work_signing`
+   - **Public key**: `~/.ssh/github_work_signing.pub`
+   - Used for signing commits in work repositories
+   - Public key must be added to GitHub as a **Signing Key**
 
 #### Initial Setup Steps
 
@@ -112,16 +118,12 @@ Git uses conditional includes to apply different settings based on repository lo
 - **URL Rewrite**: All GitHub URLs use `git@github-personal:`
 
 #### Work Repositories (`~/Documents/code/repos/`)
-- **Email**: Not set in Nix (configure manually if needed)
+- **Email**: `reis.holmes@optimizely.com` (configured in userConfig)
 - **Name**: `Reis Holmes`
-- **Commit Signing**: Disabled
+- **Commit Signing**: Enabled (SSH)
+- **Signing Key**: `~/.ssh/github_work_signing.pub`
 - **SSH Host**: `github-work` (uses work SSH key)
 - **URL Rewrite**: All GitHub URLs use `git@github-work:`
-- **Work Email Setup** (if needed):
-  ```bash
-  cd ~/Documents/code/repos
-  git config user.email "your-work-email@company.com"
-  ```
 
 ### Verification
 

--- a/hosts/rh-sb3/README.md
+++ b/hosts/rh-sb3/README.md
@@ -1,0 +1,137 @@
+# rh-sb3 Configuration
+
+Personal Linux machine configuration.
+
+## System Information
+
+- **User**: reis
+- **Configuration**: home-manager (standalone)
+
+## Git Configuration
+
+Git is managed through Nix with SSH commit signing enabled globally.
+
+### What's Automated
+
+- Git installation and base configuration
+- Delta for enhanced diffs
+- GitHub CLI credential helper
+- SSH signing configuration
+- Allowed signers file generation
+
+### Manual Setup Required
+
+#### SSH Keys
+
+The following SSH keys must be manually maintained:
+
+1. **GitHub Authentication**:
+   - Used for git operations
+   - Configured in SSH config
+
+2. **Commit Signing Key**: `/home/reis/.ssh/private-signing-key-github`
+   - **Private key**: `/home/reis/.ssh/private-signing-key-github`
+   - **Public key**: `/home/reis/.ssh/private-signing-key-github.pub`
+   - Used for signing all commits
+   - Public key must be added to GitHub as a **Signing Key**
+
+#### Initial Setup Steps
+
+1. **Import Signing Key from Proton Pass**:
+   ```bash
+   # Copy private key from Proton Pass
+   cat > ~/.ssh/private-signing-key-github
+   # Paste private key, then Ctrl+D
+
+   # Copy public key from Proton Pass
+   cat > ~/.ssh/private-signing-key-github.pub
+   # Paste public key, then Ctrl+D
+
+   # Set correct permissions
+   chmod 600 ~/.ssh/private-signing-key-github
+   chmod 644 ~/.ssh/private-signing-key-github.pub
+   ```
+
+2. **Add Signing Key to GitHub**:
+   ```bash
+   # Display public key
+   cat ~/.ssh/private-signing-key-github.pub
+   ```
+   - Go to GitHub Settings → SSH and GPG keys
+   - Click "New SSH key"
+   - Title: "rh-sb3 Commit Signing Key"
+   - Key type: **Signing Key** (important!)
+   - Paste the public key
+
+3. **Verify SSH Config**:
+   Ensure your `~/.ssh/config` has GitHub configured with your authentication key.
+
+4. **Test Configuration**:
+   ```bash
+   # Test SSH connection
+   ssh -T git@github.com
+
+   # Test commit signing
+   cd ~/Documents/code/personal_repos/*
+   git commit --allow-empty -m "test: verify signing"
+   git log --show-signature -1
+   git reset --hard HEAD~1  # Remove test commit
+   ```
+
+### Configuration Details
+
+- **Email**: `4367558+reisholmes@users.noreply.github.com` (GitHub private email)
+- **Name**: `Reis Holmes` (from userConfig)
+- **Commit Signing**: Enabled globally for all repositories
+- **Signing Format**: SSH
+- **Signing Key**: `/home/reis/.ssh/private-signing-key-github`
+
+### Verification
+
+Check your configuration:
+
+```bash
+# Show git config
+git config --list --show-origin | grep -E "(user\.|gpg\.|commit\.)"
+
+# Should show:
+# user.name=Reis Holmes
+# user.email=4367558+reisholmes@users.noreply.github.com
+# commit.gpgsign=true
+# gpg.format=ssh
+```
+
+### Troubleshooting
+
+#### Signing Not Working
+
+1. **Check signing key exists**:
+   ```bash
+   ls -la ~/.ssh/private-signing-key-github*
+   ```
+
+2. **Verify allowed_signers file**:
+   ```bash
+   cat ~/.ssh/allowed_signers
+   # Should contain: 4367558+reisholmes@users.noreply.github.com ssh-ed25519 ...
+   ```
+
+3. **Test signing**:
+   ```bash
+   cd ~/Documents/code/personal_repos/*
+   git commit --allow-empty -m "test"
+   git log --show-signature -1
+   ```
+
+## Rebuilding Configuration
+
+After making changes to your Nix configuration:
+
+```bash
+home-manager switch --flake .#reis@rh-sb3 --impure
+```
+
+Or use the alias:
+```bash
+nix_rebuild
+```

--- a/modules/home-manager/programs/git/default.nix
+++ b/modules/home-manager/programs/git/default.nix
@@ -1,13 +1,32 @@
-_: {
+{
+  lib,
+  pkgs,
+  userConfig,
+  ...
+}: {
   programs.git = {
     enable = true;
 
-    extraConfig = {
+    # Default user name from userConfig (can be overridden per-host)
+    userName = lib.mkDefault userConfig.fullName;
+    # Email is set per-host since it varies by context
+
+    # Git settings (new format)
+    settings = {
       init = {
         defaultBranch = "main";
       };
       pull = {
         rebase = false;
+      };
+      diff = {
+        colorMoved = "dimmed-zebra";
+      };
+
+      # GitHub CLI credential helper
+      credential = {
+        "https://github.com".helper = "!${pkgs.gh}/bin/gh auth git-credential";
+        "https://gist.github.com".helper = "!${pkgs.gh}/bin/gh auth git-credential";
       };
     };
 
@@ -21,8 +40,4 @@ _: {
       };
     };
   };
-
-  # Note: userName and userEmail should be configured locally via:
-  # git config --global user.name "Your Name"
-  # git config --global user.email "your.email@example.com"
 }


### PR DESCRIPTION
  - Add workEmail and workSigningKeyPub to reis.holmes userConfig
  - Enable SSH signing for work repositories
  - Generate allowed_signers file with both personal and work keys
  - Update documentation with work signing key setup